### PR TITLE
cursor tuning for MongoDB 4.2

### DIFF
--- a/mongosync/mongo/syncer.py
+++ b/mongosync/mongo/syncer.py
@@ -91,13 +91,10 @@ class MongoSyncer(CommonSyncer):
 
         while True:
             try:
-                cursor = self._src.client()[src_dbname][src_collname].find(filter=None,
-                                                                           cursor_type=pymongo.cursor.CursorType.EXHAUST,
-                                                                           no_cursor_timeout=True,
-                                                                           modifiers={'$snapshot': True})
+                cursor = self._src.client()[src_dbname][src_collname].find(no_cursor_timeout=True)
 
                 reqs = []
-                reqs_max = 200
+                reqs_max = 100
                 groups = []
                 groups_max = 10
                 n = 0
@@ -113,7 +110,7 @@ class MongoSyncer(CommonSyncer):
                         groups = []
 
                     n += 1
-                    if n % 10000 == 0:
+                    if n % 1000 == 0:
                         self._progress_logger.add(src_ns, n)
                         n = 0
 


### PR DESCRIPTION
4.2版本已经不再使用find的snapshot选项，导致cursor遍历不兼容，修改后跑起来是正常的。

```
[2020-04-30 02:07:15,223] [INFO] [293179] [progress_logger:60] >> 	HSM_V3.phyrecords	227000/236458	[96.00%]
[2020-04-30 02:07:16,494] [INFO] [293179] [progress_logger:60] >> 	HSM_V3.phyrecords	228000/236458	[96.42%]
[2020-04-30 02:07:17,605] [INFO] [293179] [progress_logger:60] >> 	HSM_V3.phyrecords	229000/236458	[96.85%]
[2020-04-30 02:07:18,679] [INFO] [293179] [progress_logger:60] >> 	HSM_V3.phyrecords	230000/236458	[97.27%]
[2020-04-30 02:07:19,847] [INFO] [293179] [progress_logger:60] >> 	HSM_V3.phyrecords	231000/236458	[97.69%]
[2020-04-30 02:07:20,966] [INFO] [293179] [progress_logger:60] >> 	HSM_V3.phyrecords	232000/236458	[98.11%]
[2020-04-30 02:07:22,195] [INFO] [293179] [progress_logger:60] >> 	HSM_V3.phyrecords	233000/236458	[98.54%]
[2020-04-30 02:07:23,425] [INFO] [293179] [progress_logger:60] >> 	HSM_V3.phyrecords	234000/236458	[98.96%]
[2020-04-30 02:07:24,661] [INFO] [293179] [progress_logger:60] >> 	HSM_V3.phyrecords	235000/236458	[99.38%]
[2020-04-30 02:07:25,884] [INFO] [293179] [progress_logger:60] >> 	HSM_V3.phyrecords	236000/236458	[99.81%]
[2020-04-30 02:07:26,463] [INFO] [293179] [progress_logger:62] >> [ OK ] 	HSM_V3.phyrecords	236458/236458	[100.00%]
[ OK ]	[1/1]	HSM_V3.phyrecords	236458/236458	428.5s
[2020-04-30 02:07:26,463] [INFO] [293179] [progress_logger:79] >> ProgressLogger thread Thread-1 exit
[2020-04-30 02:07:26,712] [INFO] [293179] [syncer:256] >> try to sync oplog from Timestamp(1588183214, 1) on user-profile-shard-00-02-xnrav.gcp.mongodb.net:27017
[2020-04-30 02:07:35,116] [INFO] [293179] [common_syncer:252] >> mongodb+srv://user-profile-xnrav.gcp.mongodb.net/HSM_V3 => 10.15.188.223:27017 - sync to 2020-04-30 02:00:14 - 441 seconds delay - Timestamp(1588183214, 1) - latest
[2020-04-30 02:07:37,816] [INFO] [293179] [common_syncer:252] >> mongodb+srv://user-profile-xnrav.gcp.mongodb.net/HSM_V3 => 10.15.188.223:27017 - sync to 2020-04-30 02:00:14 - 443 seconds delay - Timestamp(1588183214, 1) - latest
[2020-04-30 02:07:40,645] [INFO] [293179] [common_syncer:252] >> mongodb+srv://user-profile-xnrav.gcp.mongodb.net/HSM_V3 => 10.15.188.223:27017 - sync to 2020-04-30 02:00:14 - 446 seconds delay - Timestamp(1588183214, 1) - latest
[2020-04-30 02:07:43,513] [INFO] [293179] [common_syncer:252] >> mongodb+srv://user-profile-xnrav.gcp.mongodb.net/HSM_V3 => 10.15.188.223:27017 - sync to 2020-04-30 02:00:14 - 449 seconds delay - Timestamp(1588183214, 1) - latest
[2020-04-30 02:07:46,174] [INFO] [293179] [common_syncer:252] >> mongodb+srv://user-profile-xnrav.gcp.mongodb.net/HSM_V3 => 10.15.188.223:27017 - sync to 2020-04-30 02:00:14 - 452 seconds delay - Timestamp(1588183214, 1) - latest
[2020-04-30 02:07:49,042] [INFO] [293179] [common_syncer:252] >> mongodb+srv://user-profile-xnrav.gcp.mongodb.net/HSM_V3 => 10.15.188.223:27017 - sync to 2020-04-30 02:00:14 - 455 seconds delay - Timestamp(1588183214, 1) - latest

```