### PR TITLE
use timestamp of latest oplog as optime

### DIFF
--- a/mongosync/mongo_utils.py
+++ b/mongosync/mongo_utils.py
@@ -150,6 +150,11 @@ def get_optime(mc):
 
     Refer to https://docs.mongodb.com/manual/reference/command/replSetGetStatus/
     """
+    version = mc.server_info()['version']
+    if version.startswith('4.2.'):
+        doc = mc['local']['oplog.rs'].find_one(sort=[('$natural', -1)])
+        return doc['ts']
+
     rs_status = mc['admin'].command({'replSetGetStatus': 1})
     members = rs_status.get('members')
     if not members:


### PR DESCRIPTION
MongoDB 4.2复制集primary节点的optime在oplog中不一定查找到，

在原因未查明前，使用最新的oplog的时间戳作为optime。